### PR TITLE
Fix: Resolve 404 error for /coach API calls

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -10,7 +10,7 @@ server {
     }
 
     # 슬래시 유무 상관없이 프록시
-    location ~ ^/(vectorstores|files|assist|sales|events)(/|$) {
+    location ~ ^/(vectorstores|files|assist|sales|events|coach)(/|$) {
         proxy_pass http://api:8000;
 
         proxy_set_header Host $host;


### PR DESCRIPTION
The frontend was receiving a 404 Not Found error when making API calls to endpoints under the `/coach` path.

This was caused by a missing entry in the Nginx proxy configuration (`frontend/nginx.conf`). The `location` block that forwards requests to the backend API service did not include `/coach` in its path matching rule.

This change adds `coach` to the regular expression in the `location` block, ensuring that requests to `/coach/...` are correctly proxied to the `api` service.