### PR TITLE
Fix: Resolve all issues in coach feature E2E workflow

### DIFF
--- a/backend/fastapi_app.py
+++ b/backend/fastapi_app.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse, JSONResponse, PlainTextResponse, Response
+from starlette.concurrency import run_in_threadpool
 import uuid
 import os
 import base64
@@ -497,7 +498,8 @@ async def rag_query(req: RAGQueryRequest):
     """
     Performs a one-shot RAG query using the new embedding model.
     """
-    result = answer_with_rag(req.prompt, req.vectorstore_id, req.top_k)
+    # Run the synchronous, blocking function in a separate thread pool
+    result = await run_in_threadpool(answer_with_rag, req.prompt, req.vectorstore_id, req.top_k)
     return JSONResponse(result)
 
 class RAGEmbedRequest(BaseModel):


### PR DESCRIPTION
This commit provides a complete, cumulative end-to-end fix for the "coach" feature, addressing a cascade of issues discovered during debugging, from initial API errors to backend processing freezes.

The following issues were resolved:

1.  **404/405 API Errors**: Fixed the Nginx proxy to correctly route `/coach` requests and aligned the FastAPI router definition pattern to resolve initial API call failures.

2.  **Missing RAG Implementation**: The `ai_coach.py` worker was a placeholder. It has been implemented to call the central RAG API, enabling it to process user prompts and generate answers.

3.  **Result Delivery Failure via RabbitMQ**:
    - Unifed an inconsistent RabbitMQ configuration between the `api` and `backend` services by creating a single source of truth for the topology (`rabbitmq.py`).
    - Fixed a subsequent application startup crash (`PRECONDITION_FAILED`) caused by a historical inconsistency in the naming of the Dead-Letter-Exchange (`ai.dlx` vs. `ai.dlq`).

4.  **Application Freeze/Timeout**: The RAG query endpoint in the backend was calling a long-running, synchronous, blocking I/O function (`answer_with_rag`) from an `async` route. This blocked the server's event loop, causing the application to hang. This was fixed by wrapping the blocking call in `starlette.concurrency.run_in_threadpool`, allowing it to run in a separate thread without freezing the server.

With these changes, the coach feature should now be fully functional from the frontend UI to the backend processing and back.