### PR TITLE
Fix AttributeError for rabbitmq.connect

### DIFF
--- a/api/app/routes/sales.py
+++ b/api/app/routes/sales.py
@@ -64,7 +64,7 @@ async def stream_chat_responses(session_id: str):
     and streams messages to the client via SSE.
     """
     async def event_generator():
-        conn = await rabbitmq.connect()
+        conn = await rabbitmq.get_rabbitmq_connection()
         async with conn:
             ch = await conn.channel()
             # Declare an exclusive queue, it will be deleted when connection is closed


### PR DESCRIPTION
The `api` service was attempting to call a non-existent `rabbitmq.connect()` function when setting up a Server-Sent Events (SSE) stream for chat responses. This caused an `AttributeError`.

This commit replaces the incorrect call with the correct function, `rabbitmq.get_rabbitmq_connection()`, which is available in the `api/app/rabbitmq.py` module. This resolves the error and allows the SSE stream to connect to RabbitMQ correctly.