### PR TITLE
Fix AttributeError for rabbitmq.publish_chat_message

### DIFF
--- a/api/app/routes/sales.py
+++ b/api/app/routes/sales.py
@@ -102,7 +102,7 @@ async def post_chat_message(req: ChatRequest):
         "thread_id": req.thread_id,
         "timestamp": datetime.utcnow().isoformat()
     }
-    await rabbitmq.publish_chat_message(payload)
+    await rabbitmq.publish_task("sim.chat", payload)
     return {"status": "message published"}
 
 @router.get("/tts/live/{session_id}")


### PR DESCRIPTION
The `api` service was attempting to call a non-existent `rabbitmq.publish_chat_message()` function when publishing a chat message to the backend. This caused an `AttributeError`.

This commit replaces the incorrect call with the correct function, `rabbitmq.publish_task()`, and provides the appropriate routing key 'sim.chat' to route the message to the simulation worker. This resolves the error and allows chat messages to be published correctly.