### PR TITLE
fix: Enrich text for RAG embeddings

### DIFF
--- a/api/app/routes/coach.py
+++ b/api/app/routes/coach.py
@@ -50,9 +50,9 @@ def _safe_payload(v: Any):
 def build_course_text(row: Dict[str, Any]) -> str:
     parts = []
     for key in [
-        "course_title","topic","learning_objectives","keywords",
-        "prerequisites","instructor_name","language","difficulty",
-        "target_audience","interactivity_level","accessibility_features"
+        "course_title", "product_line", "topic", "learning_objectives", "keywords",
+        "prerequisites", "instructor_name", "language", "difficulty",
+        "target_audience", "interactivity_level", "accessibility_features"
     ]:
         val = row.get(key)
         if val is not None and str(val).strip():


### PR DESCRIPTION
The root cause of the poor RAG performance was identified as insufficient data being included in the text used to generate vector embeddings. Specifically, the `product_line` field was omitted, making it difficult for the semantic search to distinguish between different product categories (e.g., Mobile vs. TV/AV).

This commit modifies the `build_course_text` function to include the `product_line` field when constructing the text to be embedded.

IMPORTANT: For this change to take effect, all existing course data must be re-indexed.