### PR TITLE
feat(api): Replace 'coach' with 'picks' for Galaxy Picks feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ open http://localhost:6333/dashboard
 
 ## 엔드포인트 요약
 
-### 파일/코칭(문서 및 추천)
-- `POST /coach/documents` → 새 문서 컬렉션 생성 → `{ id }` 반환
+### 파일/Galaxy Picks(문서 및 추천)
+- `POST /picks/documents` → 새 문서 컬렉션 생성 → `{ id }` 반환
 - `POST /files/upload?user_id=U&vectorstore_id=VS` (multipart) → MinIO 저장 + `vectorstore.files` 메타 업데이트
-- `POST /coach/documents/{id}/index` → MinIO 파일을 읽어 **청크→임베딩→Qdrant 업서트** (PoC: `.txt/.md` 지원)
+- `POST /picks/documents/{id}/index` → MinIO 파일을 읽어 **청크→임베딩→Qdrant 업서트** (PoC: `.txt/.md` 지원)
 
 ### 작업 생성
-- `POST /coach/recommendations` | `/galaxy` | `/translate`
+- `POST /picks/recommendations` | `/galaxy` | `/translate`
   → `{ job_id, thread_id, status_url }` 반환 (메시지는 `ai.tasks`로 발행)
 
 ### 이벤트 스트림 (SSE)
@@ -58,8 +58,8 @@ es.onerror = e => es.close();
 
 ## RabbitMQ 토폴로지
 - Exchanges: `ai.tasks`(topic), `ai.results`(topic), `ai.dlq`(fanout)
-- Queues: `q.assist`, `q.galaxy`, `q.coach`, `q.translate`, `q.sim.control`, `q.dlq`
-- 라우팅키: `assist.* | galaxy.* | coach.* | translate.* | sim.control.*`
+- Queues: `q.assist`, `q.galaxy`, `q.picks`, `q.translate`, `q.sim.control`, `q.dlq`
+- 라우팅키: `assist.* | galaxy.* | picks.* | translate.* | sim.control.*`
 
 ## Mongo 인덱스
 부팅 시 자동 보장(API `ensure_indexes`).
@@ -68,7 +68,7 @@ es.onerror = e => es.close();
 
 1) **문서 컬렉션 생성**
 ```bash
-curl.exe -sX POST "http://localhost:8000/coach/documents"
+curl.exe -sX POST "http://localhost:8000/picks/documents"
 
 # -> { "id": "<vs_id>" }
 ```
@@ -81,13 +81,13 @@ curl.exe -s -F "file=@README.md" "http://localhost:8000/files/upload?user_id=u1&
 
 3) **인덱싱(Qdrant 업서트)**
 ```bash
-curl.exe -sX POST "http://localhost:8000/coach/documents/689d7670ec5d54b6610cf3a5/index"
+curl.exe -sX POST "http://localhost:8000/picks/documents/689d7670ec5d54b6610cf3a5/index"
 
 ```
 
-4) **코칭(추천) 작업 생성(+RAG)**
+4) **Galaxy Picks(추천) 작업 생성(+RAG)**
 ```bash
-$JOB = (curl.exe -sL -X POST "http://localhost:8000/coach/recommendations" `
+$JOB = (curl.exe -sL -X POST "http://localhost:8000/picks/recommendations" `
   -H "Content-Type: application/json" `
   -d '{"user_id":"u1","prompt":"What course should I take?","vectorstore_id":"689d7670ec5d54b6610cf3a5","sub_function":"recommendation"}' `
   | ConvertFrom-Json).job_id
@@ -111,7 +111,7 @@ curl.exe -N "http://localhost:8000/events/jobs/$JOB"
 ```
 api/
   app/
-    routes/ (coach, galaxy, translate, files, events, sim, misc, sales)
+    routes/ (picks, galaxy, translate, files, events, sim, misc, sales)
     rabbitmq.py, db.py, storage.py, vector.py, config.py, schemas.py, rag_utils.py
 backend/
   sales_persona_backend/

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .routes import galaxy, coach, translate, files, events, sim, misc, sales
+from .routes import galaxy, picks, translate, files, events, sim, misc, sales
 from . import rabbitmq
 from .db import ensure_indexes
 from .config import settings
@@ -32,7 +32,7 @@ async def on_startup():
     await ensure_indexes(settings.app_org_id)
 
 # 라우터 등록
-app.include_router(coach.router, prefix="/coach", tags=["coach"])
+app.include_router(picks.router, prefix="/picks", tags=["picks"])
 app.include_router(galaxy.router, prefix="/galaxy", tags=["galaxy"])
 app.include_router(translate.router, prefix="/translate", tags=["translate"])
 app.include_router(files.router, prefix="/files", tags=["files"])

--- a/api/app/rabbitmq.py
+++ b/api/app/rabbitmq.py
@@ -31,13 +31,13 @@ DLX_EXCHANGE     = os.getenv("DLX_EXCHANGE", "ai.dlq") # FIX: Mismatch with exis
 
 Q_ASSIST     = os.getenv("Q_ASSIST",     "q.assist")
 Q_GALAXY     = os.getenv("Q_GALAXY",     "q.galaxy")
-Q_COACH      = os.getenv("Q_COACH",      "q.coach")
+Q_PICKS      = os.getenv("Q_PICKS",      "q.picks")
 Q_TRANSLATE  = os.getenv("Q_TRANSLATE",  "q.translate")
 Q_SIM        = os.getenv("Q_SIM",        "q.sim.control")
 
 RK_ASSIST     = os.getenv("RK_ASSIST",     "assist.*")
 RK_GALAXY     = os.getenv("RK_GALAXY",     "galaxy.*")
-RK_COACH      = os.getenv("RK_COACH",      "coach.*")
+RK_PICKS      = os.getenv("RK_PICKS",      "picks.*")
 RK_TRANSLATE  = os.getenv("RK_TRANSLATE",  "translate.*")
 RK_SIM        = os.getenv("RK_SIM",        "sim.*")
 
@@ -87,21 +87,21 @@ async def declare_topology(channel: Any) -> Dict[str, aio_pika.Queue]:
     # 큐
     q_assist = await channel.declare_queue(Q_ASSIST, durable=True, arguments=args_with_dlx)
     q_galaxy = await channel.declare_queue(Q_GALAXY, durable=True, arguments=args_with_dlx)
-    q_coach  = await channel.declare_queue(Q_COACH,  durable=True, arguments=args_with_dlx)
+    q_picks  = await channel.declare_queue(Q_PICKS,  durable=True, arguments=args_with_dlx)
     q_trans  = await channel.declare_queue(Q_TRANSLATE, durable=True, arguments=args_with_dlx)
     q_sim    = await channel.declare_queue(Q_SIM, durable=True, arguments=args_with_dlx)
 
     # 바인딩
     await q_assist.bind(TASKS_EXCHANGE, RK_ASSIST)
     await q_galaxy.bind(TASKS_EXCHANGE, RK_GALAXY)
-    await q_coach.bind(TASKS_EXCHANGE, RK_COACH)
+    await q_picks.bind(TASKS_EXCHANGE, RK_PICKS)
     await q_trans.bind(TASKS_EXCHANGE, RK_TRANSLATE)
     await q_sim.bind(TASKS_EXCHANGE, RK_SIM)
 
     # DLQ 큐들
     await channel.declare_queue(f"{Q_ASSIST}{DLQ_SUFFIX}", durable=True)
     await channel.declare_queue(f"{Q_GALAXY}{DLQ_SUFFIX}", durable=True)
-    await channel.declare_queue(f"{Q_COACH}{DLQ_SUFFIX}",  durable=True)
+    await channel.declare_queue(f"{Q_PICKS}{DLQ_SUFFIX}",  durable=True)
     await channel.declare_queue(f"{Q_TRANSLATE}{DLQ_SUFFIX}", durable=True)
     await channel.declare_queue(f"{Q_SIM}{DLQ_SUFFIX}", durable=True)
 
@@ -109,7 +109,7 @@ async def declare_topology(channel: Any) -> Dict[str, aio_pika.Queue]:
         "chat": chat_queue,
         "assist": q_assist,
         "galaxy": q_galaxy,
-        "coach": q_coach,
+        "picks": q_picks,
         "translate": q_trans,
         "sim": q_sim,
     }

--- a/api/app/routes/picks.py
+++ b/api/app/routes/picks.py
@@ -12,7 +12,7 @@ from ..rag_utils import chunk_text, embed_texts, DIM
 from ..schemas import JobRequest, JobResponse
 
 router = APIRouter(
-    tags=["coach"],
+    tags=["Galaxy Picks"],
 )
 
 # RAG document storage endpoints (from vectorstores.py)
@@ -238,13 +238,13 @@ async def index_vectorstore(vectorstore_id: str, max_points: int = 20000):
     return {"indexed": total_indexed, "collection": f"vs_{vectorstore_id}"}
 
 
-# Course recommendation endpoint (from assist.py)
+# Galaxy Picks endpoint
 
 @router.post("/recommendations", response_model=JobResponse)
-async def recommend_courses(req: JobRequest):
-    """Triggers a course recommendation task."""
-    FUNCTION_NAME = "coach"
-    ROUTING_KEY = "coach.request"
+async def recommend_picks(req: JobRequest):
+    """Triggers a Galaxy Picks recommendation task."""
+    FUNCTION_NAME = "picks"
+    ROUTING_KEY = "picks.request"
 
     await ensure_indexes(settings.app_org_id)
     db = inst_db(settings.app_org_id)

--- a/backend/sales_persona_backend/rabbitmq.py
+++ b/backend/sales_persona_backend/rabbitmq.py
@@ -31,13 +31,13 @@ DLX_EXCHANGE     = os.getenv("DLX_EXCHANGE", "ai.dlq") # FIX: Mismatch with exis
 
 Q_ASSIST     = os.getenv("Q_ASSIST",     "q.assist")
 Q_GALAXY     = os.getenv("Q_GALAXY",     "q.galaxy")
-Q_COACH      = os.getenv("Q_COACH",      "q.coach")
+Q_PICKS      = os.getenv("Q_PICKS",      "q.picks")
 Q_TRANSLATE  = os.getenv("Q_TRANSLATE",  "q.translate")
 Q_SIM        = os.getenv("Q_SIM",        "q.sim.control")
 
 RK_ASSIST     = os.getenv("RK_ASSIST",     "assist.*")
 RK_GALAXY     = os.getenv("RK_GALAXY",     "galaxy.*")
-RK_COACH      = os.getenv("RK_COACH",      "coach.*")
+RK_PICKS      = os.getenv("RK_PICKS",      "picks.*")
 RK_TRANSLATE  = os.getenv("RK_TRANSLATE",  "translate.*")
 RK_SIM        = os.getenv("RK_SIM",        "sim.*")
 
@@ -87,21 +87,21 @@ async def declare_topology(channel: Any) -> Dict[str, aio_pika.Queue]:
     # 큐
     q_assist = await channel.declare_queue(Q_ASSIST, durable=True, arguments=args_with_dlx)
     q_galaxy = await channel.declare_queue(Q_GALAXY, durable=True, arguments=args_with_dlx)
-    q_coach  = await channel.declare_queue(Q_COACH,  durable=True, arguments=args_with_dlx)
+    q_picks  = await channel.declare_queue(Q_PICKS,  durable=True, arguments=args_with_dlx)
     q_trans  = await channel.declare_queue(Q_TRANSLATE, durable=True, arguments=args_with_dlx)
     q_sim    = await channel.declare_queue(Q_SIM, durable=True, arguments=args_with_dlx)
 
     # 바인딩
     await q_assist.bind(TASKS_EXCHANGE, RK_ASSIST)
     await q_galaxy.bind(TASKS_EXCHANGE, RK_GALAXY)
-    await q_coach.bind(TASKS_EXCHANGE, RK_COACH)
+    await q_picks.bind(TASKS_EXCHANGE, RK_PICKS)
     await q_trans.bind(TASKS_EXCHANGE, RK_TRANSLATE)
     await q_sim.bind(TASKS_EXCHANGE, RK_SIM)
 
     # DLQ 큐들
     await channel.declare_queue(f"{Q_ASSIST}{DLQ_SUFFIX}", durable=True)
     await channel.declare_queue(f"{Q_GALAXY}{DLQ_SUFFIX}", durable=True)
-    await channel.declare_queue(f"{Q_COACH}{DLQ_SUFFIX}",  durable=True)
+    await channel.declare_queue(f"{Q_PICKS}{DLQ_SUFFIX}",  durable=True)
     await channel.declare_queue(f"{Q_TRANSLATE}{DLQ_SUFFIX}", durable=True)
     await channel.declare_queue(f"{Q_SIM}{DLQ_SUFFIX}", durable=True)
 
@@ -109,7 +109,7 @@ async def declare_topology(channel: Any) -> Dict[str, aio_pika.Queue]:
         "chat": chat_queue,
         "assist": q_assist,
         "galaxy": q_galaxy,
-        "coach": q_coach,
+        "picks": q_picks,
         "translate": q_trans,
         "sim": q_sim,
     }

--- a/backend/sales_persona_backend/worker/ai_picks.py
+++ b/backend/sales_persona_backend/worker/ai_picks.py
@@ -3,7 +3,7 @@ from .. import ai
 
 async def run(payload: dict) -> dict:
     """
-    Handles the 'coach' task by calling the main RAG function from the parent ai module.
+    Handles the 'picks' task by calling the main RAG function from the parent ai module.
     """
     prompt = payload.get("prompt")
     vs_id = payload.get("vectorstore_id")

--- a/backend/sales_persona_backend/worker/main.py
+++ b/backend/sales_persona_backend/worker/main.py
@@ -11,10 +11,10 @@ from aio_pika import IncomingMessage
 from sales_persona_backend import rabbitmq
 
 try:
-    from . import ai_assist, ai_galaxy, ai_coach, ai_translate, ai_sim
+    from . import ai_assist, ai_galaxy, ai_picks, ai_translate, ai_sim
 except ImportError as e:
     print(f"Could not import AI modules: {e}")
-    ai_assist = ai_galaxy = ai_coach = ai_translate = ai_sim = None
+    ai_assist = ai_galaxy = ai_picks = ai_translate = ai_sim = None
 
 
 async def _dispatch_task(routing_key: str, payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -24,8 +24,8 @@ async def _dispatch_task(routing_key: str, payload: Dict[str, Any]) -> Dict[str,
         return await ai_assist.run(payload)
     if prefix == "galaxy" and ai_galaxy and hasattr(ai_galaxy, "run"):
         return await ai_galaxy.run(payload)
-    if prefix == "coach" and ai_coach and hasattr(ai_coach, "run"):
-        return await ai_coach.run(payload)
+    if prefix == "picks" and ai_picks and hasattr(ai_picks, "run"):
+        return await ai_picks.run(payload)
     if prefix == "translate" and ai_translate and hasattr(ai_translate, "run"):
         return await ai_translate.run(payload)
     if prefix == "sim" and ai_sim and hasattr(ai_sim, "control"):
@@ -73,7 +73,7 @@ async def run_task_consumer(shutdown_event: asyncio.Event):
         all_queues = await rabbitmq.declare_topology(channel)
         worker_queues = {
             name: queue for name, queue in all_queues.items()
-            if name in ["assist", "galaxy", "coach", "translate", "sim"]
+            if name in ["assist", "galaxy", "picks", "translate", "sim"]
         }
 
         print(f" [x] Waiting for worker tasks on queues: {list(worker_queues.keys())}")

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -10,7 +10,7 @@ server {
     }
 
     # 슬래시 유무 상관없이 프록시
-    location ~ ^/(vectorstores|files|assist|sales|events|coach)(/|$) {
+    location ~ ^/(vectorstores|files|assist|sales|events|picks)(/|$) {
         proxy_pass http://api:8000;
 
         proxy_set_header Host $host;

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -53,7 +53,7 @@ document.addEventListener('DOMContentLoaded', () => {
         ragEvidence.innerHTML = '';
         log(ragResult, '1. Creating vector store...');
         try {
-            const vsResponse = await fetch('/coach/documents', { method: 'POST' });
+            const vsResponse = await fetch('/picks/documents', { method: 'POST' });
             if (!vsResponse.ok) throw new Error(`Failed to create document store (${vsResponse.status})`);
             const vsData = await vsResponse.json();
             vectorstoreId = vsData.id;
@@ -67,7 +67,7 @@ document.addEventListener('DOMContentLoaded', () => {
             log(ragResult, '   File uploaded successfully.');
 
             log(ragResult, '3. Indexing file...');
-            const indexResponse = await fetch(`/coach/documents/${vectorstoreId}/index`, { method: 'POST' });
+            const indexResponse = await fetch(`/picks/documents/${vectorstoreId}/index`, { method: 'POST' });
             if (!indexResponse.ok) throw new Error(`Failed to index file (${indexResponse.status})`);
             const indexData = await indexResponse.json();
             log(ragResult, `   Indexing complete. ${indexData.indexed} points added.`);
@@ -85,7 +85,7 @@ document.addEventListener('DOMContentLoaded', () => {
         ragResult.textContent = 'Thinking...';
         ragEvidence.innerHTML = '';
         try {
-            const response = await fetch('/coach/recommendations', {
+            const response = await fetch('/picks/recommendations', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ user_id: 'frontend_user', prompt: prompt, vectorstore_id: vectorstoreId }),

--- a/run_rag.ps1
+++ b/run_rag.ps1
@@ -68,7 +68,7 @@ try {
     $FilePath = (Resolve-Path -LiteralPath $FilePath).Path
 
     Write-Host "1) Creating document collection..." -ForegroundColor Cyan
-    $vsResp = Invoke-CurlJson -Method "POST" -Url "$BaseUrl/coach/documents"
+    $vsResp = Invoke-CurlJson -Method "POST" -Url "$BaseUrl/picks/documents"
     $vsId = $vsResp.id
     if (-not $vsId) { throw "Failed to create vectorstore. Response:`n$($vsResp | ConvertTo-Json -Depth 6)" }
     Write-Host "   -> vectorstore_id: $vsId" -ForegroundColor Green
@@ -80,7 +80,7 @@ try {
     else { Write-Host "   -> upload ok" -ForegroundColor Green }
 
     Write-Host "3) Indexing (Qdrant upsert)..." -ForegroundColor Cyan
-    $idxResp = Invoke-CurlJson -Method "POST" -Url "$BaseUrl/coach/documents/$vsId/index"
+    $idxResp = Invoke-CurlJson -Method "POST" -Url "$BaseUrl/picks/documents/$vsId/index"
     if (-not $idxResp) { Write-Warning "Index response was empty or not JSON." }
     else { Write-Host "   -> index requested" -ForegroundColor Green }
 
@@ -94,7 +94,7 @@ try {
 
     # Escape quotes for curl.exe -d "<json>" (wrap later, so keep backslashes)
     $escapedBody = $body.Replace('"','\"')
-    $assistUrl = "$BaseUrl/coach/recommendations"
+    $assistUrl = "$BaseUrl/picks/recommendations"
     $jobResp = Invoke-CurlJson -Method "POST" -Url $assistUrl -BodyJson $escapedBody
     $jobId = $jobResp.job_id
     if (-not $jobId) {


### PR DESCRIPTION
This commit renames all occurrences of the 'coach' feature to 'picks' to align with the new 'Galaxy Picks' naming convention.

Changes include:
- Renamed API endpoints from /coach to /picks.
- Updated router tags to 'Galaxy Picks' for documentation.
- Renamed RabbitMQ queues and routing keys from 'coach' to 'picks'.
- Renamed backend worker files and updated logic accordingly.
- Updated frontend NGINX configuration, JavaScript API calls, documentation, and example scripts.